### PR TITLE
feat: only highlight dates at which there exist certain diary

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,7 +27,8 @@ function getFirstAndLastFile(files) {
 
   return {
     first: sorted[0],
-    last: sorted[sorted.length - 1]
+    last: sorted[sorted.length - 1],
+    files: sorted.join(','),
   };
 }
 

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -11,8 +11,10 @@ window.addEventListener('load', function() {
   var picker = new Pikaday({
     onSelect: function(date) {
       var time = moment(date);
-      window.location.href += time.format('YYYY/MM/YYYY-MM-DD') + '.html';
-      // a bug of pikaday whose fix is still not released
+      if ( enableDates.indexOf(time.format('YYYY-MM-DD')) > -1 ) {
+        window.location.href += '/' + time.format('YYYY/MM/YYYY-MM-DD') + '.html';
+        // a bug of pikaday whose fix is still not released
+      }
     },
     i18n: {
         previousMonth : '&lt;&lt;',

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -6,6 +6,7 @@ window.addEventListener('load', function() {
   var calendar = document.getElementById('calendar');
   var lastDate = new Date(calendar.getAttribute('data-last-date'));
   var firstDate = new Date(calendar.getAttribute('data-first-date'));
+  var enableDates = calendar.getAttribute('data-dates').split(',');
 
   var picker = new Pikaday({
     onSelect: function(date) {
@@ -21,7 +22,11 @@ window.addEventListener('load', function() {
         weekdaysShort : ['Sun','Mon','Tue','Wed','Thu','Fri','Sat']
     },
     minDate: firstDate,
-    maxDate: lastDate
+    maxDate: lastDate,
+    disableDayFn: function(date) {
+      date = moment(date).format('YYYY-MM-DD');
+      return enableDates.indexOf(date) === -1;
+    }
   });
 
   calendar.appendChild(picker.el);

--- a/src/templates/index.jade
+++ b/src/templates/index.jade
@@ -12,7 +12,7 @@ block style
 
 block content
   .content
-    #calendar(data-last-date=last, data-first-date=first)
+    #calendar(data-last-date=last, data-first-date=first, data-dates=files)
 
 block script
   script(src='#{base_url}/scripts/vendor.bundle.js')


### PR DESCRIPTION
## Target Problem

By now, all dates between `startDate` and `endDate` in the Pikaday calendar could be clicked, which would guide users to a **404 not found** page when there's no diary at the selected date.
## Solution

use `disableDayFn` of [Pikaday](https://www.npmjs.com/package/pikaday)  to disable all invalid dates (i.e: there's no diary at that day).
## Screenshot

![image](https://cloud.githubusercontent.com/assets/1009294/17275360/7163ce36-5737-11e6-8690-f62ef04e6c3a.png)
